### PR TITLE
Fix bad URI(is not URI?): PlanningRegisterDetails.aspx?id=0042/11 - 2 (URI::InvalidURIError)

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -15,7 +15,7 @@ page = form.submit
 
 page.at("table#ctl00_phContent_gvPlanningRegister").search('tr')[1..-1].each do |r|
   record = {
-    'info_url' => (page.uri + r.at('a')['href']).to_s,
+    'info_url' => (page.uri + URI.encode(r.at('a')['href'])).to_s,
     'comment_url' => "mailto:council@stonnington.vic.gov.au",
     'council_reference' => r.search('td')[0].inner_text,
     'date_received' => Date.strptime(r.search('td')[1].inner_text.strip, '%d/%m/%Y').to_s,


### PR DESCRIPTION
Fixes

```
Successfully built d7971676bd3f
 /app/vendor/ruby-1.9.3/lib/ruby/1.9.1/uri/generic.rb:1202:in `rescue in merge': bad URI(is not URI?): PlanningRegisterDetails.aspx?id=0042/11 - 2 (URI::InvalidURIError)
    from /app/vendor/ruby-1.9.3/lib/ruby/1.9.1/uri/generic.rb:1199:in `merge'
    from scraper.rb:18:in `block in <main>'
    from /app/vendor/bundle/ruby/1.9.1/gems/nokogiri-1.5.0/lib/nokogiri/xml/node_set.rb:239:in `block in each'
    from /app/vendor/bundle/ruby/1.9.1/gems/nokogiri-1.5.0/lib/nokogiri/xml/node_set.rb:238:in `upto'
    from /app/vendor/bundle/ruby/1.9.1/gems/nokogiri-1.5.0/lib/nokogiri/xml/node_set.rb:238:in `each'
    from scraper.rb:16:in `<main>'
```
